### PR TITLE
Add HTML document type and XML namespace

### DIFF
--- a/src/tinyhttpd.cpp
+++ b/src/tinyhttpd.cpp
@@ -219,7 +219,8 @@ void ServeDirectoryListing(int ClientSocket, const std::string &directoryPath,
   std::stringstream response;
   response << "\r\n";
   response
-      << "<html><head>"
+      << "<!DOCTYPE html>"
+         "<html xmlns='http://www.w3.org/1999/xhtml'><head>"
          "<title>Directory Listing</title></head>"
          "<style>"
          "html, body { height: 100%; margin: 0; }"


### PR DESCRIPTION
Add HTML document type to ensure served document, when rendered, does not trigger quirks mode (per HTML5 spec, §13). Also added default (optional) XHTML namespace declaration.